### PR TITLE
Update order mutations - explicitly save changed fields in `DraftOrderUpdate`

### DIFF
--- a/.github/workflows/create-tag-with-release-pr.yml
+++ b/.github/workflows/create-tag-with-release-pr.yml
@@ -46,7 +46,7 @@ jobs:
           VERSION: ${{ steps.set-version.outputs.VERSION }}
           IS_LATEST: ${{ steps.check-latest.outputs.IS_LATEST }}
         run: |
-          gh release create -d "$VERSION" --repo="$GITHUB_REPOSITORY" --latest="$IS_LATEST" --generate-notes --verify-tag
+          gh release create "$VERSION" --repo="$GITHUB_REPOSITORY" --latest="$IS_LATEST" --generate-notes --verify-tag
 
   publish:
     needs:

--- a/saleor/graphql/order/mutations/draft_order_cleaner.py
+++ b/saleor/graphql/order/mutations/draft_order_cleaner.py
@@ -1,0 +1,136 @@
+from typing import Optional
+
+from django.core.exceptions import ValidationError
+
+from ....channel.models import Channel
+from ....core.utils.url import validate_storefront_url
+from ....discount.models import Voucher, VoucherCode
+from ....discount.utils.voucher import (
+    get_active_voucher_code,
+    get_voucher_code_instance,
+)
+from ....order.error_codes import OrderErrorCode
+
+
+def clean_redirect_url(redirect_url: str, cleaned_input: dict):
+    if not redirect_url:
+        return
+
+    try:
+        validate_storefront_url(redirect_url)
+    except ValidationError as error:
+        error.code = OrderErrorCode.INVALID.value
+        raise ValidationError({"redirect_url": error})
+
+    cleaned_input["redirect_url"] = redirect_url
+
+
+def clean_voucher_and_voucher_code(channel: "Channel", cleaned_input: dict):
+    voucher = cleaned_input.get("voucher", None)
+    voucher_code = cleaned_input.get("voucher_code", None)
+    if voucher and voucher_code:
+        raise ValidationError(
+            {
+                "voucher": ValidationError(
+                    "You cannot use both a voucher and a voucher code for the same "
+                    "order. Please choose one.",
+                    code=OrderErrorCode.INVALID.value,
+                )
+            }
+        )
+
+    if "voucher" in cleaned_input:
+        clean_voucher(voucher, channel, cleaned_input)
+    elif "voucher_code" in cleaned_input:
+        clean_voucher_code(voucher_code, channel, cleaned_input)
+
+
+def clean_voucher(voucher: Optional[Voucher], channel: Channel, cleaned_input: dict):
+    # We need to clean voucher_code as well
+    if voucher is None:
+        cleaned_input["voucher_code"] = None
+        return
+
+    if isinstance(voucher, VoucherCode):
+        raise ValidationError(
+            {
+                "voucher": ValidationError(
+                    "You cannot use voucherCode in the voucher input. "
+                    "Please use voucherCode input instead with a valid voucher code.",
+                    code=OrderErrorCode.INVALID_VOUCHER.value,
+                )
+            }
+        )
+
+    code_instance = None
+    if channel.include_draft_order_in_voucher_usage:
+        # Validate voucher when it's included in voucher usage calculation
+        try:
+            code_instance = get_active_voucher_code(voucher, channel.slug)
+        except ValidationError:
+            raise ValidationError(
+                {
+                    "voucher": ValidationError(
+                        "Voucher is invalid.",
+                        code=OrderErrorCode.INVALID_VOUCHER.value,
+                    )
+                }
+            )
+    else:
+        clean_voucher_listing(voucher, channel, "voucher")
+    if not code_instance:
+        code_instance = voucher.codes.first()
+    if code_instance:
+        cleaned_input["voucher_code"] = code_instance.code
+        cleaned_input["voucher_code_instance"] = code_instance
+
+
+def clean_voucher_code(
+    voucher_code: Optional[str], channel: Channel, cleaned_input: dict
+):
+    # We need to clean voucher instance as well
+    if voucher_code is None:
+        cleaned_input["voucher"] = None
+        return
+    if channel.include_draft_order_in_voucher_usage:
+        # Validate voucher when it's included in voucher usage calculation
+        try:
+            code_instance = get_voucher_code_instance(voucher_code, channel.slug)
+        except ValidationError:
+            raise ValidationError(
+                {
+                    "voucher_code": ValidationError(
+                        "Voucher code is invalid.",
+                        code=OrderErrorCode.INVALID_VOUCHER_CODE.value,
+                    )
+                }
+            )
+        voucher = code_instance.voucher
+    else:
+        code_instance = VoucherCode.objects.filter(code=voucher_code).first()
+        if not code_instance:
+            raise ValidationError(
+                {
+                    "voucher": ValidationError(
+                        "Invalid voucher code.",
+                        code=OrderErrorCode.INVALID_VOUCHER_CODE.value,
+                    )
+                }
+            )
+        voucher = code_instance.voucher
+        clean_voucher_listing(voucher, channel, "voucher_code")
+    cleaned_input["voucher"] = voucher
+    cleaned_input["voucher_code"] = voucher_code
+    cleaned_input["voucher_code_instance"] = code_instance
+
+
+def clean_voucher_listing(voucher: "Voucher", channel: "Channel", field: str):
+    if not voucher.channel_listings.filter(channel=channel).exists():
+        raise ValidationError(
+            {
+                field: ValidationError(
+                    "Voucher not available for this order.",
+                    code=OrderErrorCode.NOT_AVAILABLE_IN_CHANNEL.value,
+                )
+            }
+        )

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -1,20 +1,53 @@
 import graphene
 from django.core.exceptions import ValidationError
 
+from ....account.models import User
+from ....checkout import AddressType
+from ....core.tracing import traced_atomic_transaction
+from ....discount.models import VoucherCode
+from ....discount.utils.voucher import (
+    increase_voucher_usage,
+    release_voucher_code_usage,
+)
 from ....order import OrderStatus, models
+from ....order.actions import call_order_event
 from ....order.error_codes import OrderErrorCode
+from ....order.search import update_order_search_vector
+from ....order.utils import (
+    invalidate_order_prices,
+    update_order_display_gross_prices,
+)
 from ....permission.enums import OrderPermissions
-from ...app.dataloaders import get_app_promise
+from ....webhook.event_types import WebhookEventAsyncType
+from ...account.i18n import I18nMixin
+from ...account.mixins import AddressMetadataMixin
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_310
-from ...core.mutations import ModelWithExtRefMutation
+from ...core.descriptions import (
+    ADDED_IN_310,
+)
+from ...core.mutations import (
+    ModelWithExtRefMutation,
+    ModelWithRestrictedChannelAccessMutation,
+)
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
+from ...shipping.utils import get_shipping_model_by_object_id
 from ..types import Order
-from .draft_order_create import DraftOrderCreate, DraftOrderInput
+from . import draft_order_cleaner
+from .draft_order_create import DraftOrderInput
+from .utils import (
+    SHIPPING_METHOD_UPDATE_FIELDS,
+    ShippingMethodUpdateMixin,
+    save_addresses,
+)
 
 
-class DraftOrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
+class DraftOrderUpdate(
+    AddressMetadataMixin,
+    ModelWithRestrictedChannelAccessMutation,
+    ModelWithExtRefMutation,
+    I18nMixin,
+):
     class Arguments:
         id = graphene.ID(required=False, description="ID of a draft order to update.")
         external_reference = graphene.String(
@@ -63,48 +96,208 @@ class DraftOrderUpdate(DraftOrderCreate, ModelWithExtRefMutation):
         )
 
     @classmethod
-    def save(cls, info: ResolveInfo, instance, cleaned_input):
+    def clean_input(
+        cls, info: ResolveInfo, instance: models.Order, data: dict, **kwargs
+    ):
+        cls.clean_channel_id(instance, data)
         manager = get_plugin_manager_promise(info.context).get()
-        app = get_app_promise(info.context).get()
-        return cls._save_draft_order(
-            info,
-            instance,
-            cleaned_input,
-            is_new_instance=False,
-            app=app,
-            manager=manager,
+        shipping_address = data.pop("shipping_address", None)
+        billing_address = data.pop("billing_address", None)
+        redirect_url = data.pop("redirect_url", None)
+
+        shipping_method_input = {}
+        if "shipping_method" in data:
+            shipping_method_input["shipping_method"] = get_shipping_model_by_object_id(
+                object_id=data.pop("shipping_method", None),
+                error_field="shipping_method",
+            )
+
+        if email := data.get("user_email", None):
+            try:
+                user = User.objects.get(email=email, is_active=True)
+                data["user"] = graphene.Node.to_global_id("User", user.id)
+            except User.DoesNotExist:
+                data["user"] = None
+
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+
+        cleaned_input.update(shipping_method_input)
+
+        channel = instance.channel or cleaned_input.get("channel_id")
+        draft_order_cleaner.clean_voucher_and_voucher_code(channel, cleaned_input)
+
+        cls.clean_addresses(
+            info, instance, cleaned_input, shipping_address, billing_address, manager
         )
+
+        draft_order_cleaner.clean_redirect_url(redirect_url, cleaned_input)
+
+        return cleaned_input
+
+    @classmethod
+    def clean_channel_id(cls, instance, data):
+        if data.get("channel_id"):
+            if hasattr(instance, "channel"):
+                raise ValidationError(
+                    {
+                        "channel_id": ValidationError(
+                            "Can't update existing order channel id.",
+                            code=OrderErrorCode.NOT_EDITABLE.value,
+                        )
+                    }
+                )
+
+    @classmethod
+    def clean_addresses(
+        cls,
+        info: ResolveInfo,
+        instance,
+        cleaned_input,
+        shipping_address,
+        billing_address,
+        manager,
+    ):
+        if shipping_address:
+            shipping_address = cls.validate_address(
+                shipping_address,
+                address_type=AddressType.SHIPPING,
+                instance=instance.shipping_address,
+                info=info,
+            )
+            manager.change_user_address(shipping_address, "shipping", user=instance)
+            cleaned_input["shipping_address"] = shipping_address
+        if billing_address:
+            billing_address = cls.validate_address(
+                billing_address,
+                address_type=AddressType.BILLING,
+                instance=instance.billing_address,
+                info=info,
+            )
+            manager.change_user_address(billing_address, "billing", user=instance)
+            cleaned_input["billing_address"] = billing_address
+
+    @classmethod
+    def _save(
+        cls,
+        info: ResolveInfo,
+        instance,
+        cleaned_input,
+        old_voucher,
+        old_voucher_code,
+        changed_fields,
+    ):
+        updated_fields = changed_fields
+        manager = get_plugin_manager_promise(info.context).get()
+        with traced_atomic_transaction():
+            # Process addresses
+            address_fields = save_addresses(instance, cleaned_input)
+            updated_fields.extend(address_fields)
+
+            if "shipping_method" in cleaned_input:
+                method = cleaned_input["shipping_method"]
+                if method is None:
+                    ShippingMethodUpdateMixin.clear_shipping_method_from_order(instance)
+                else:
+                    ShippingMethodUpdateMixin.process_shipping_method(
+                        instance, method, manager
+                    )
+                updated_fields.extend(SHIPPING_METHOD_UPDATE_FIELDS)
+
+            if instance.undiscounted_base_shipping_price_amount is None:
+                instance.undiscounted_base_shipping_price_amount = (
+                    instance.base_shipping_price_amount
+                )
+                updated_fields.append("undiscounted_base_shipping_price_amount")
+
+            if "voucher" in cleaned_input:
+                cls.handle_order_voucher(
+                    cleaned_input,
+                    instance,
+                    old_voucher,
+                    old_voucher_code,
+                )
+
+            if not updated_fields:
+                return
+
+            if (
+                "shipping_address" in updated_fields
+                or "billing_address" in updated_fields
+            ):
+                update_order_display_gross_prices(instance)
+                updated_fields.append("display_gross_prices")
+
+            if updated_fields:
+                update_order_search_vector(instance, save=False)
+                # Post-process the results
+                updated_fields.extend(
+                    [
+                        "search_vector",
+                        "updated_at",
+                    ]
+                )
+
+                if cls.should_invalidate_prices(cleaned_input):
+                    invalidate_order_prices(instance)
+                    updated_fields.extend(["should_refresh_prices"])
+
+                instance.save(update_fields=updated_fields)
+
+            # The event is fired to not introduce the breaking change in 3.20.
+            # Won't be triggered in the next minor version in case nothing changed.
+            call_order_event(
+                manager,
+                WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
+                instance,
+            )
+
+    @classmethod
+    def handle_order_voucher(
+        cls, cleaned_input, instance, old_voucher, old_voucher_code
+    ):
+        user_email = instance.user_email or instance.user and instance.user.email
+        channel = instance.channel
+        if not channel.include_draft_order_in_voucher_usage:
+            return
+
+        if voucher := cleaned_input["voucher"]:
+            code_instance = cleaned_input.pop("voucher_code_instance", None)
+            increase_voucher_usage(
+                voucher,
+                code_instance,
+                user_email,
+                increase_voucher_customer_usage=False,
+            )
+        elif old_voucher:
+            # handle removing voucher
+            voucher_code = VoucherCode.objects.filter(code=old_voucher_code).first()
+            release_voucher_code_usage(voucher_code, old_voucher, user_email)
 
     @classmethod
     def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
         instance = cls.get_instance(info, **data)
         channel_id = cls.get_instance_channel_id(instance, **data)
         cls.check_channel_permissions(info, [channel_id])
+        old_instance_data = instance.serialize_for_comparison()
         old_voucher = instance.voucher
         old_voucher_code = instance.voucher_code
-        data = data.get("input")
+        data = data["input"]
         cleaned_input = cls.clean_input(info, instance, data)
         instance = cls.construct_instance(instance, cleaned_input)
         cls.clean_instance(info, instance)
-        cls.save_draft_order(
-            info, instance, cleaned_input, old_voucher, old_voucher_code
+        new_instance_data = instance.serialize_for_comparison()
+        changed_fields = cls.diff_instance_data_fields(
+            instance.comparison_fields,
+            old_instance_data,
+            new_instance_data,
+        )
+        cls._save(
+            info, instance, cleaned_input, old_voucher, old_voucher_code, changed_fields
         )
         cls._save_m2m(info, instance, cleaned_input)
         return cls.success_response(instance)
 
     @classmethod
-    def save_draft_order(
-        cls, info: ResolveInfo, instance, cleaned_input, old_voucher, old_voucher_code
-    ):
-        manager = get_plugin_manager_promise(info.context).get()
-        app = get_app_promise(info.context).get()
-        return cls._save_draft_order(
-            info,
-            instance,
-            cleaned_input,
-            is_new_instance=False,
-            app=app,
-            manager=manager,
-            old_voucher=old_voucher,
-            old_voucher_code=old_voucher_code,
-        )
+    def get_instance_channel_id(cls, instance, **data):
+        if channel_id := instance.channel_id:
+            return channel_id

--- a/saleor/graphql/order/mutations/order_update_shipping.py
+++ b/saleor/graphql/order/mutations/order_update_shipping.py
@@ -1,12 +1,11 @@
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....order import OrderStatus, models
+from ....order import models
 from ....order.actions import call_order_event
 from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
 from ....shipping import models as shipping_models
-from ....shipping.utils import convert_to_shipping_method_data
 from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.doc_category import DOC_CATEGORY_ORDERS
@@ -19,7 +18,6 @@ from .utils import (
     SHIPPING_METHOD_UPDATE_FIELDS,
     EditableOrderValidationMixin,
     ShippingMethodUpdateMixin,
-    clean_order_update_shipping,
 )
 
 
@@ -34,9 +32,7 @@ class OrderUpdateShippingInput(BaseInputObjectType):
         doc_category = DOC_CATEGORY_ORDERS
 
 
-class OrderUpdateShipping(
-    EditableOrderValidationMixin, ShippingMethodUpdateMixin, BaseMutation
-):
+class OrderUpdateShipping(EditableOrderValidationMixin, BaseMutation):
     order = graphene.Field(Order, description="Order with updated shipping method.")
 
     class Arguments:
@@ -108,7 +104,7 @@ class OrderUpdateShipping(
                     }
                 )
 
-            cls.clear_shipping_method_from_order(order)
+            ShippingMethodUpdateMixin.clear_shipping_method_from_order(order)
             order.save(update_fields=SHIPPING_METHOD_UPDATE_FIELDS)
             return OrderUpdateShipping(order=order)
 
@@ -122,17 +118,8 @@ class OrderUpdateShipping(
                 "postal_code_rules"
             ),
         )
-        shipping_channel_listing = cls.validate_shipping_channel_listing(method, order)
-
-        shipping_method_data = convert_to_shipping_method_data(
-            method,
-            shipping_channel_listing,
-        )
         manager = get_plugin_manager_promise(info.context).get()
-        if order.status != OrderStatus.DRAFT:
-            clean_order_update_shipping(order, shipping_method_data, manager)
-        cls.update_shipping_method(order, method, shipping_channel_listing)
-        cls._update_shipping_price(order, shipping_channel_listing)
+        ShippingMethodUpdateMixin.process_shipping_method(order, method, manager)
 
         order.save(update_fields=SHIPPING_METHOD_UPDATE_FIELDS)
         # Post-process the results

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -8,6 +8,7 @@ import pytz
 from django.test import override_settings
 from prices import Money
 
+from .....account.models import Address
 from .....checkout import AddressType
 from .....core.models import EventDelivery
 from .....core.prices import quantize_price
@@ -170,6 +171,8 @@ def test_draft_order_create_with_voucher_entire_order(
         {"variantId": variant_0_id, "quantity": variant_0_qty},
         {"variantId": variant_1_id, "quantity": variant_1_qty},
     ]
+
+    address_count = Address.objects.count()
     shipping_address = graphql_address_data
     shipping_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
     voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
@@ -287,6 +290,9 @@ def test_draft_order_create_with_voucher_entire_order(
 
     for line in order_lines:
         assert line.is_price_overridden is False
+
+    # ensure shipping and billing address instances were created
+    assert Address.objects.count() == address_count + 2
 
 
 def test_draft_order_create_with_voucher_and_voucher_code(

--- a/saleor/graphql/order/tests/mutations/test_draft_order_update.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_update.py
@@ -2265,7 +2265,7 @@ def test_draft_order_update_replace_entire_order_voucher_with_shipping_voucher(
 
 
 @patch(
-    "saleor.graphql.order.mutations.draft_order_create.call_order_event",
+    "saleor.graphql.order.mutations.draft_order_update.call_order_event",
     wraps=call_order_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")
@@ -2362,7 +2362,7 @@ def test_draft_order_update_triggers_webhooks(
 
 
 @patch(
-    "saleor.graphql.order.mutations.draft_order_create.call_order_event",
+    "saleor.graphql.order.mutations.draft_order_update.call_order_event",
     wraps=call_order_event,
 )
 @patch("saleor.webhook.transport.synchronous.transport.send_webhook_request_sync")

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -1,3 +1,4 @@
+import copy
 from decimal import Decimal
 from operator import attrgetter
 from re import match
@@ -11,6 +12,7 @@ from django.core.validators import MinValueValidator
 from django.db import connection, models
 from django.db.models import F, JSONField, Max
 from django.db.models.expressions import Exists, OuterRef
+from django.forms.models import model_to_dict
 from django.utils.timezone import now
 from django_measurement.models import MeasurementField
 from django_prices.models import MoneyField, TaxedMoneyField
@@ -512,6 +514,23 @@ class Order(ModelWithMetadata, ModelWithExternalReference):
     @property
     def total_balance(self):
         return self.total_charged - self.total.gross
+
+    @property
+    def comparison_fields(self):
+        return [
+            "discount",
+            "voucher",
+            "voucher_code",
+            "customer_note",
+            "redirect_url",
+            "external_reference",
+            "user",
+            "user_email",
+            "channel",
+        ]
+
+    def serialize_for_comparison(self):
+        return copy.deepcopy(model_to_dict(self, fields=self.comparison_fields))
 
 
 class OrderLineQueryset(models.QuerySet["OrderLine"]):


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17498

- Refactor `DraftOrderUpdate` and `DraftOrderCreate` - do not inherit from `draftOrderCreate` in `draftOrderUpdate` mutation.
- Save only changed fields in `DraftOrderUpdate`.
- Introduce `DraftOrderCleaner` to encapsulate `DraftOrderCreate` and `DraftOrderUpdate` clean methods
- Do not inherit from `ShippingMethodUpdateMixin` - use just methods from Mixin

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [...